### PR TITLE
가상환경이 아닌 실제 PC에서 소수점 계산 중 GP exception 발생하는 문제 해결

### DIFF
--- a/02.Kernel64/Source/Task.c
+++ b/02.Kernel64/Source/Task.c
@@ -323,6 +323,7 @@ void kInitializeScheduler( void )
     pstTask->qwMemorySize = 0x500000;
     pstTask->pvStackAddress = ( void* ) 0x600000;
     pstTask->qwStackSize = 0x100000;
+    pstTask->bFPUUsed = FALSE;
     
     // 프로세서 사용률을 계산하는데 사용하는 자료구조 초기화
     gs_vstScheduler[ bCurrentAPICID ].qwSpendProcessorTimeInIdleTask = 0;


### PR DESCRIPTION
오랫만이예요. 학교 공부떄문에 잠시동안 OS 공부를 못했는데 이제 방학동안에 다시 계속 공부할려고 합니다.

이 [이슈](https://github.com/kkamagui/mint64os/issues/9)에 대한 commit입니다.